### PR TITLE
Rename crate & setup release 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "abomonation_derive"
-version = "0.5.0"
+name = "abomonation_derive_ng"
+version = "0.1.0"
 authors = ["Nika Layzell <nika@thelayzells.com>"]
 description = "A custom derive plugin for abomonation"
 license = "MIT"
 repository = "https://github.com/lurk-lab/abomonation_derive"
-documentation = "https://docs.rs/abomonation_derive"
+documentation = "https://docs.rs/abomonation_derive_ng"
 edition = "2021"
 rust-version = "1.63"
 
 [lib]
-name = "abomonation_derive"
+name = "abomonation_derive_ng"
 proc-macro = true
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "abomonation_derive_ng"
 version = "0.1.0"
-authors = ["Nika Layzell <nika@thelayzells.com>"]
+authors = ["Lurk Lab Engineering <engineering@lurk-lab.com", "Nika Layzell <nika@thelayzells.com>"]
 description = "A custom derive plugin for abomonation"
 license = "MIT"
 repository = "https://github.com/lurk-lab/abomonation_derive"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# abomonation_derive
+# abomonation_derive_ng
 
 Derive macro implementation for the Abomonation crate. Forked & improved from [the original `abomonation_derive` crate from @mystor](https://github.com/mystor/abomonation_derive).
 
@@ -10,7 +10,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-abomonation_derive = "0.1"
+abomonation_derive_ng = "0.1"
 abomonation = "0.5"
 ```
 
@@ -18,7 +18,7 @@ Then, derive `Abomonation` on your types:
 
 ```rust
 #[macro_use]
-extern crate abomonation_derive;
+extern crate abomonation_derive_ng;
 extern crate abomonation;
 use abomonation::Abomonation;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,7 +4,7 @@
 mod tests {
 
     use abomonation::*;
-    use abomonation_derive::Abomonation;
+    use abomonation_derive_ng::Abomonation;
 
     #[derive(Eq, PartialEq, Abomonation)]
     pub struct Struct {


### PR DESCRIPTION
Not to be merged until downstream is using the crate.
https://crates.io/crates/abomonation_derive